### PR TITLE
Add options to specific path contains config and dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import (
 )
 
 func main() {
-    s2t, err := gocc.New("s2t")
+    s2t, err := gocc.New("s2t", make(map[string]interface{}))
     if err != nil {
         log.Fatal(err)
     }

--- a/opencc_test.go
+++ b/opencc_test.go
@@ -15,7 +15,9 @@ func TestConvert(t *testing.T) {
 	}
 
 	for k := range conversions {
-		s2t, err := New(k)
+		opt := make(map[string]interface{})
+		opt["path"] = "."
+		s2t, err := New(k, opt)
 		if err != nil {
 			t.Errorf("New %s error:%+v", k, err)
 		}


### PR DESCRIPTION
+ Options in New method of OpenCC, to allow specific path to configs and dictionaries
+ Update README and test case